### PR TITLE
Replace configuration compile and testCompile

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,14 +21,14 @@ repositories {
 
 dependencies {
     asciidoctorGems 'rubygems:rouge:3.15.0'
-    compile 'org.slf4j:slf4j-api:1.7.22'
-    compile 'org.codehaus.groovy:groovy-all:2.4.9'
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.mockito:mockito-all:1.9.5'
-    testCompile 'com.lesfurets:jenkins-pipeline-unit:1.1'
-    testCompile('org.spockframework:spock-core:1.1-groovy-2.4')
-    //testCompile 'org.jenkins-ci.main:jenkins-core:2.73.3'
-    testCompile 'org.jenkins-ci.main:jenkins-core:2.+'
+    implementation 'org.slf4j:slf4j-api:1.7.22'
+    implementation 'org.codehaus.groovy:groovy-all:2.4.9'
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.mockito:mockito-all:1.9.5'
+    testImplementation 'com.lesfurets:jenkins-pipeline-unit:1.1'
+    testImplementation('org.spockframework:spock-core:1.1-groovy-2.4')
+    //testImplementation 'org.jenkins-ci.main:jenkins-core:2.73.3'
+    testImplementation 'org.jenkins-ci.main:jenkins-core:2.+'
 }
 
 final BUILD_DATE = new Date().format('dd.MM.yyyy').toString()


### PR DESCRIPTION
The configurations compile and testCompile are deprecated and
are replaced with implementation and testImplementation to
avoid problems with Gradle 7.0.

fix #5